### PR TITLE
Handle missing market cap data

### DIFF
--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -30,7 +30,7 @@ def valuation_agent(state: AgentState):
         if not financial_metrics:
             progress.update_status("valuation_agent", ticker, "Failed: No financial metrics found")
             continue
-        
+
         metrics = financial_metrics[0]
 
         progress.update_status("valuation_agent", ticker, "Gathering line items")
@@ -86,6 +86,10 @@ def valuation_agent(state: AgentState):
         progress.update_status("valuation_agent", ticker, "Comparing to market value")
         # Get the market cap
         market_cap = get_market_cap(ticker=ticker, end_date=end_date)
+
+        if not market_cap or market_cap <= 0:
+            progress.update_status("valuation_agent", ticker, "Failed: Market cap not found")
+            continue
 
         # Calculate combined valuation gap (average of both methods)
         dcf_gap = (dcf_value - market_cap) / market_cap

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -134,9 +134,7 @@ def get_insider_trades(
     # Check cache first
     if cached_data := _cache.get_insider_trades(ticker):
         # Filter cached data by date range
-        filtered_data = [InsiderTrade(**trade) for trade in cached_data 
-                        if (start_date is None or (trade.get("transaction_date") or trade["filing_date"]) >= start_date)
-                        and (trade.get("transaction_date") or trade["filing_date"]) <= end_date]
+        filtered_data = [InsiderTrade(**trade) for trade in cached_data if (start_date is None or (trade.get("transaction_date") or trade["filing_date"]) >= start_date) and (trade.get("transaction_date") or trade["filing_date"]) <= end_date]
         filtered_data.sort(key=lambda x: x.transaction_date or x.filing_date, reverse=True)
         if filtered_data:
             return filtered_data
@@ -148,33 +146,33 @@ def get_insider_trades(
 
     all_trades = []
     current_end_date = end_date
-    
+
     while True:
         url = f"https://api.financialdatasets.ai/insider-trades/?ticker={ticker}&filing_date_lte={current_end_date}"
         if start_date:
             url += f"&filing_date_gte={start_date}"
         url += f"&limit={limit}"
-        
+
         response = requests.get(url, headers=headers)
         if response.status_code != 200:
             raise Exception(f"Error fetching data: {ticker} - {response.status_code} - {response.text}")
-        
+
         data = response.json()
         response_model = InsiderTradeResponse(**data)
         insider_trades = response_model.insider_trades
-        
+
         if not insider_trades:
             break
-            
+
         all_trades.extend(insider_trades)
-        
+
         # Only continue pagination if we have a start_date and got a full page
         if not start_date or len(insider_trades) < limit:
             break
-            
+
         # Update end_date to the oldest filing date from current batch for next iteration
-        current_end_date = min(trade.filing_date for trade in insider_trades).split('T')[0]
-        
+        current_end_date = min(trade.filing_date for trade in insider_trades).split("T")[0]
+
         # If we've reached or passed the start_date, we can stop
         if current_end_date <= start_date:
             break
@@ -197,9 +195,7 @@ def get_company_news(
     # Check cache first
     if cached_data := _cache.get_company_news(ticker):
         # Filter cached data by date range
-        filtered_data = [CompanyNews(**news) for news in cached_data 
-                        if (start_date is None or news["date"] >= start_date)
-                        and news["date"] <= end_date]
+        filtered_data = [CompanyNews(**news) for news in cached_data if (start_date is None or news["date"] >= start_date) and news["date"] <= end_date]
         filtered_data.sort(key=lambda x: x.date, reverse=True)
         if filtered_data:
             return filtered_data
@@ -211,33 +207,33 @@ def get_company_news(
 
     all_news = []
     current_end_date = end_date
-    
+
     while True:
         url = f"https://api.financialdatasets.ai/news/?ticker={ticker}&end_date={current_end_date}"
         if start_date:
             url += f"&start_date={start_date}"
         url += f"&limit={limit}"
-        
+
         response = requests.get(url, headers=headers)
         if response.status_code != 200:
             raise Exception(f"Error fetching data: {ticker} - {response.status_code} - {response.text}")
-        
+
         data = response.json()
         response_model = CompanyNewsResponse(**data)
         company_news = response_model.news
-        
+
         if not company_news:
             break
-            
+
         all_news.extend(company_news)
-        
+
         # Only continue pagination if we have a start_date and got a full page
         if not start_date or len(company_news) < limit:
             break
-            
+
         # Update end_date to the oldest date from current batch for next iteration
-        current_end_date = min(news.date for news in company_news).split('T')[0]
-        
+        current_end_date = min(news.date for news in company_news).split("T")[0]
+
         # If we've reached or passed the start_date, we can stop
         if current_end_date <= start_date:
             break
@@ -250,13 +246,15 @@ def get_company_news(
     return all_news
 
 
-
 def get_market_cap(
     ticker: str,
     end_date: str,
 ) -> float | None:
     """Fetch market cap from the API."""
     financial_metrics = get_financial_metrics(ticker, end_date)
+    if not financial_metrics:
+        return None
+
     market_cap = financial_metrics[0].market_cap
     if not market_cap:
         return None


### PR DESCRIPTION
## Summary
- avoid IndexError in `get_market_cap` when no metrics are returned
- skip valuation calculation if market cap is missing

## Testing
- `black src/tools/api.py src/agents/valuation.py`

## Summary by Sourcery

Handle missing market cap data gracefully by returning None in the API and skipping valuation when market cap is absent or non-positive

Bug Fixes:
- Return None from get_market_cap when no financial metrics are available or market cap is missing to avoid IndexError
- Skip valuation_agent processing for tickers without a valid market cap to prevent invalid valuation calculations