### PR TITLE
Fix misc Any type hints

### DIFF
--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -4,6 +4,7 @@ from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -278,7 +279,7 @@ def analyze_valuation_graham(metrics: list, financial_line_items: list, market_c
 
 def generate_graham_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> BenGrahamSignal:

--- a/src/agents/bill_ackman.py
+++ b/src/agents/bill_ackman.py
@@ -4,6 +4,7 @@ from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -337,7 +338,7 @@ def analyze_valuation(financial_line_items: list, market_cap: float) -> dict:
 
 def generate_ackman_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> BillAckmanSignal:

--- a/src/agents/cathie_wood.py
+++ b/src/agents/cathie_wood.py
@@ -4,6 +4,7 @@ from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -421,7 +422,7 @@ def analyze_cathie_wood_valuation(financial_line_items: list, market_cap: float)
 
 def generate_cathie_wood_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> CathieWoodSignal:

--- a/src/agents/charlie_munger.py
+++ b/src/agents/charlie_munger.py
@@ -3,6 +3,7 @@ from tools.api import get_financial_metrics, get_market_cap, search_line_items, 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -661,7 +662,7 @@ def analyze_news_sentiment(news_items: list) -> str:
 
 def generate_munger_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> CharlieMungerSignal:

--- a/src/agents/phil_fisher.py
+++ b/src/agents/phil_fisher.py
@@ -9,6 +9,7 @@ from tools.api import (
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -527,7 +528,7 @@ def analyze_sentiment(news_items: list) -> dict:
 
 def generate_fisher_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> PhilFisherSignal:

--- a/src/agents/stanley_druckenmiller.py
+++ b/src/agents/stanley_druckenmiller.py
@@ -10,6 +10,7 @@ from tools.api import (
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from utils.progress import progress
@@ -520,7 +521,7 @@ def analyze_druckenmiller_valuation(financial_line_items: list, market_cap: floa
 
 def generate_druckenmiller_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> StanleyDruckenmillerSignal:

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -2,6 +2,7 @@ from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
+from typing import Any
 import json
 from typing_extensions import Literal
 from tools.api import get_financial_metrics, get_market_cap, search_line_items
@@ -134,7 +135,7 @@ def warren_buffett_agent(state: AgentState):
     return {"messages": [message], "data": state["data"]}
 
 
-def analyze_fundamentals(metrics: list) -> dict[str, any]:
+def analyze_fundamentals(metrics: list) -> dict[str, Any]:
     """Analyze company fundamentals based on Buffett's criteria."""
     if not metrics:
         return {"score": 0, "details": "Insufficient fundamental data"}
@@ -183,7 +184,7 @@ def analyze_fundamentals(metrics: list) -> dict[str, any]:
     return {"score": score, "details": "; ".join(reasoning), "metrics": latest_metrics.model_dump()}
 
 
-def analyze_consistency(financial_line_items: list) -> dict[str, any]:
+def analyze_consistency(financial_line_items: list) -> dict[str, Any]:
     """Analyze earnings consistency and growth."""
     if len(financial_line_items) < 4:  # Need at least 4 periods for trend analysis
         return {"score": 0, "details": "Insufficient historical data"}
@@ -216,7 +217,7 @@ def analyze_consistency(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def analyze_moat(metrics: list) -> dict[str, any]:
+def analyze_moat(metrics: list) -> dict[str, Any]:
     """
     Evaluate whether the company likely has a durable competitive advantage (moat).
     For simplicity, we look at stability of ROE/operating margins over multiple periods
@@ -266,7 +267,7 @@ def analyze_moat(metrics: list) -> dict[str, any]:
     }
 
 
-def analyze_management_quality(financial_line_items: list) -> dict[str, any]:
+def analyze_management_quality(financial_line_items: list) -> dict[str, Any]:
     """
     Checks for share dilution or consistent buybacks, and some dividend track record.
     A simplified approach:
@@ -306,7 +307,7 @@ def analyze_management_quality(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def calculate_owner_earnings(financial_line_items: list) -> dict[str, any]:
+def calculate_owner_earnings(financial_line_items: list) -> dict[str, Any]:
     """Calculate owner earnings (Buffett's preferred measure of true earnings power).
     Owner Earnings = Net Income + Depreciation - Maintenance CapEx"""
     if not financial_line_items or len(financial_line_items) < 1:
@@ -332,7 +333,7 @@ def calculate_owner_earnings(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def calculate_intrinsic_value(financial_line_items: list) -> dict[str, any]:
+def calculate_intrinsic_value(financial_line_items: list) -> dict[str, Any]:
     """Calculate intrinsic value using DCF with owner earnings."""
     if not financial_line_items:
         return {"intrinsic_value": None, "details": ["Insufficient data for valuation"]}
@@ -384,7 +385,7 @@ def calculate_intrinsic_value(financial_line_items: list) -> dict[str, any]:
 
 def generate_buffett_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> WarrenBuffettSignal:

--- a/src/data/cache.py
+++ b/src/data/cache.py
@@ -1,12 +1,14 @@
+from typing import Any
+
 class Cache:
     """In-memory cache for API responses."""
 
     def __init__(self):
-        self._prices_cache: dict[str, list[dict[str, any]]] = {}
-        self._financial_metrics_cache: dict[str, list[dict[str, any]]] = {}
-        self._line_items_cache: dict[str, list[dict[str, any]]] = {}
-        self._insider_trades_cache: dict[str, list[dict[str, any]]] = {}
-        self._company_news_cache: dict[str, list[dict[str, any]]] = {}
+        self._prices_cache: dict[str, list[dict[str, Any]]] = {}
+        self._financial_metrics_cache: dict[str, list[dict[str, Any]]] = {}
+        self._line_items_cache: dict[str, list[dict[str, Any]]] = {}
+        self._insider_trades_cache: dict[str, list[dict[str, Any]]] = {}
+        self._company_news_cache: dict[str, list[dict[str, Any]]] = {}
 
     def _merge_data(self, existing: list[dict] | None, new_data: list[dict], key_field: str) -> list[dict]:
         """Merge existing and new data, avoiding duplicates based on a key field."""
@@ -21,43 +23,43 @@ class Cache:
         merged.extend([item for item in new_data if item[key_field] not in existing_keys])
         return merged
 
-    def get_prices(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_prices(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached price data if available."""
         return self._prices_cache.get(ticker)
 
-    def set_prices(self, ticker: str, data: list[dict[str, any]]):
+    def set_prices(self, ticker: str, data: list[dict[str, Any]]):
         """Append new price data to cache."""
         self._prices_cache[ticker] = self._merge_data(self._prices_cache.get(ticker), data, key_field="time")
 
-    def get_financial_metrics(self, ticker: str) -> list[dict[str, any]]:
+    def get_financial_metrics(self, ticker: str) -> list[dict[str, Any]]:
         """Get cached financial metrics if available."""
         return self._financial_metrics_cache.get(ticker)
 
-    def set_financial_metrics(self, ticker: str, data: list[dict[str, any]]):
+    def set_financial_metrics(self, ticker: str, data: list[dict[str, Any]]):
         """Append new financial metrics to cache."""
         self._financial_metrics_cache[ticker] = self._merge_data(self._financial_metrics_cache.get(ticker), data, key_field="report_period")
 
-    def get_line_items(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_line_items(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached line items if available."""
         return self._line_items_cache.get(ticker)
 
-    def set_line_items(self, ticker: str, data: list[dict[str, any]]):
+    def set_line_items(self, ticker: str, data: list[dict[str, Any]]):
         """Append new line items to cache."""
         self._line_items_cache[ticker] = self._merge_data(self._line_items_cache.get(ticker), data, key_field="report_period")
 
-    def get_insider_trades(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_insider_trades(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached insider trades if available."""
         return self._insider_trades_cache.get(ticker)
 
-    def set_insider_trades(self, ticker: str, data: list[dict[str, any]]):
+    def set_insider_trades(self, ticker: str, data: list[dict[str, Any]]):
         """Append new insider trades to cache."""
         self._insider_trades_cache[ticker] = self._merge_data(self._insider_trades_cache.get(ticker), data, key_field="filing_date")  # Could also use transaction_date if preferred
 
-    def get_company_news(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_company_news(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached company news if available."""
         return self._company_news_cache.get(ticker)
 
-    def set_company_news(self, ticker: str, data: list[dict[str, any]]):
+    def set_company_news(self, ticker: str, data: list[dict[str, Any]]):
         """Append new company news to cache."""
         self._company_news_cache[ticker] = self._merge_data(self._company_news_cache.get(ticker), data, key_field="date")
 

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing_extensions import Annotated, Sequence, TypedDict
 
 import operator
@@ -7,15 +8,15 @@ from langchain_core.messages import BaseMessage
 import json
 
 
-def merge_dicts(a: dict[str, any], b: dict[str, any]) -> dict[str, any]:
+def merge_dicts(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
     return {**a, **b}
 
 
 # Define agent state
 class AgentState(TypedDict):
     messages: Annotated[Sequence[BaseMessage], operator.add]
-    data: Annotated[dict[str, any], merge_dicts]
-    metadata: Annotated[dict[str, any], merge_dicts]
+    data: Annotated[dict[str, Any], merge_dicts]
+    metadata: Annotated[dict[str, Any], merge_dicts]
 
 
 def show_agent_reasoning(output, agent_name):

--- a/src/utils/display.py
+++ b/src/utils/display.py
@@ -1,3 +1,4 @@
+from typing import Any
 from colorama import Fore, Style
 from tabulate import tabulate
 from .analysts import ANALYST_ORDER
@@ -323,7 +324,7 @@ def format_backtest_row(
     sharpe_ratio: float = None,
     sortino_ratio: float = None,
     max_drawdown: float = None,
-) -> list[any]:
+) -> list[Any]:
     """Format a row for the backtest results table"""
     # Color the action
     action_color = {


### PR DESCRIPTION
## Summary
- fix incorrect type hint usage of `any`
- update agent outputs to use `typing.Any`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Enhancements:
- Replace lowercase “any” in dict and list type hints with “typing.Any” in cache, agent, state, and utility modules